### PR TITLE
Add remove-bot-stars configuration option

### DIFF
--- a/bots/starboard/bot/commands/configuration/removebotstars.js
+++ b/bots/starboard/bot/commands/configuration/removebotstars.js
@@ -1,0 +1,20 @@
+const { Command } = require('../../../../../');
+
+class RemoveBotStars extends Command {
+	constructor() {
+		super({
+			description: 'Toggles whether or not bot stars are removed.',
+			memberPerms: 'MANAGE_MESSAGES',
+		});
+	}
+
+	async run(msg) {
+		const remove = this.client.settings.get(msg.guild.id, 'removebotreacts', true);
+		if (!msg.member.hasPermission('ADMINISTRATOR') && !msg.owner) return msg.channel.send(`Bot stars are${remove ? ' ' : ' not'} removed.`);
+		await this.client.settings.set(msg.guild.id, 'removebotreacts', !remove);
+
+		return msg.channel.send(`Bot stars are ${remove ? 'no longer' : 'now being'} removed.`);
+	}
+}
+
+module.exports = RemoveBotStars;

--- a/bots/starboard/bot/commands/configuration/removebotstars.js
+++ b/bots/starboard/bot/commands/configuration/removebotstars.js
@@ -1,6 +1,6 @@
 const { Command } = require('../../../../../');
 
-class RemoveBotStars extends Command {
+class RemoveBotStarsCommand extends Command {
 	constructor() {
 		super({
 			description: 'Toggles whether or not bot stars are removed.',

--- a/bots/starboard/bot/commands/configuration/removebotstars.js
+++ b/bots/starboard/bot/commands/configuration/removebotstars.js
@@ -10,7 +10,9 @@ class RemoveBotStarsCommand extends Command {
 
 	async run(msg) {
 		const remove = this.client.settings.get(msg.guild.id, 'removebotreacts', true);
-		if (!msg.member.hasPermission('ADMINISTRATOR') && !msg.owner) return msg.channel.send(`Bot stars are${remove ? ' ' : ' not'} removed.`);
+		if (!msg.member.hasPermission('ADMINISTRATOR') && 
+!msg.owner) return msg.channel.send(`Bot stars are ${remove ? '' : 
+'not'} removed.`);
 		await this.client.settings.set(msg.guild.id, 'removebotreacts', !remove);
 
 		return msg.channel.send(`Bot stars are ${remove ? 'no longer' : 'now being'} removed.`);

--- a/bots/starboard/bot/events/raw/MESSAGE_REACTION_ADD.js
+++ b/bots/starboard/bot/events/raw/MESSAGE_REACTION_ADD.js
@@ -18,7 +18,16 @@ exports.run = async (data, client) => {
 	const blacklisted = await client.blacklists.has([message.author.id, channel.id], channel.guild.id);
 	if (blacklisted) return;
 
-	if (message.author.id === data.user_id) {
+	const removeBotReacts = client.settings.get(channel.guild.id, 'removebotreacts', true);
+
+	const reactor = await client.users.get(data.user_id);
+	if (reactor.bot)
+		if (removeBotReacts)
+			return message.reactions.get(emoji).users.remove(data.user_id);
+
+	const selfStar = client.settings.get(channel.guild.id, 'selfstar', false);
+
+	if (message.author.id === data.user_id && !selfStar) {
 		if (!warned[message.id] && channel.permissionsFor(client.user).has('SEND_MESSAGES'))
 			message.reply('you can\'t star your own messages!');
 

--- a/bots/starboard/bot/events/raw/MESSAGE_REACTION_ADD.js
+++ b/bots/starboard/bot/events/raw/MESSAGE_REACTION_ADD.js
@@ -20,10 +20,9 @@ exports.run = async (data, client) => {
 
 	const removeBotReacts = client.settings.get(channel.guild.id, 'removebotreacts', true);
 
-	const reactor = await client.users.get(data.user_id);
-	if (reactor.bot)
-		if (removeBotReacts)
-			return message.reactions.get(emoji).users.remove(data.user_id);
+	const reactor = client.users.get(data.user_id);
+	if (reactor.bot && removeBotReacts)
+		return message.reactions.get(emoji).users.remove(data.user_id);
 
 	const selfStar = client.settings.get(channel.guild.id, 'selfstar', false);
 


### PR DESCRIPTION
If true, star reactions made by bots will be removed.

Only problem is that `events/raw/MESSAGE_REACTION_ADD` includes changes from the other pull request I made.